### PR TITLE
Added option for multiple cover pages to be added

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,6 @@ TODO
 
 - Support math role and directive.
 - Support tabular_col_spec directive.
-- Support URL path for images.
 
 *******
 Licence

--- a/docxbuilder/__init__.py
+++ b/docxbuilder/__init__.py
@@ -28,7 +28,7 @@ def setup(app):
     app.add_config_value('docx_pagebreak_before_file', 0, 'env')
     app.add_config_value('docx_pagebreak_before_table_of_contents', -1, 'env')
     app.add_config_value('docx_pagebreak_after_table_of_contents', 0, 'env')
-    app.add_config_value('docx_coverpage', True, 'env')
+    app.add_config_value('docx_coverpage', 1, 'env')
     app.add_config_value('docx_update_fields', False, 'env')
     app.add_config_value('docx_table_options', {
         'landscape_columns': 0,

--- a/docxbuilder/docx/docx.py
+++ b/docxbuilder/docx/docx.py
@@ -1183,11 +1183,12 @@ class DocxDocument: # pylint: disable=too-many-public-methods
             '//w:sdt[w:sdtPr/w:docPartObj/w:docPartGallery[@w:val="Cover Pages"]]')
         return copy.deepcopy(coverpages[0]) if coverpages else None
 
-    def get_first_section_elements(self):
-        return self._get_elements_until_target('./*[.//w:pPr/w:sectPr][1]')
+    def get_first_section_elements(self, n=1):
+        return self._get_elements_until_target('./*[.//w:pPr/w:sectPr][%d]' % n)
 
-    def get_first_page_elements(self):
-        return self._get_elements_until_target('./*[.//w:br[@w:type="page"]][1]')
+    def get_first_page_elements(self, n=1):
+        return self._get_elements_until_target('./*[.//w:br[@w:type="page"]][%d]' % n)
+
     def get_image_numbers(self):
         img_nums = []
         for path in self.docx.namelist():
@@ -1390,7 +1391,7 @@ def collect_referenced_footnotes(footnotes, xml):
 
 
 class DocxComposer: # pylint: disable=too-many-public-methods
-    def __init__(self, stylefile, has_coverpage):
+    def __init__(self, stylefile, cover_pages):
         '''
            Constructor
         '''
@@ -1420,8 +1421,8 @@ class DocxComposer: # pylint: disable=too-many-public-methods
 
         self.document = make_element_tree([['w:document'], [['w:body']]])
         self.docbody = get_elements(self.document, '/w:document/w:body')[0]
-        if has_coverpage:
-            self.docbody.extend(self.get_coverpage_elements())
+        if cover_pages:
+            self.docbody.extend(self.get_coverpage_elements(cover_pages))
 
         footnote_info = collect_referenced_footnotes(
             self.style_docx.footnotes, self.docbody)
@@ -1432,16 +1433,10 @@ class DocxComposer: # pylint: disable=too-many-public-methods
         self._run_style_property_cache = {}
         self._table_margin_cache = {}
 
-    def get_coverpage_elements(self):
-        coverpage = self.style_docx.get_coverpage()
-        if coverpage is not None:
-            return [coverpage]
-        first_section_elems = self.style_docx.get_first_section_elements()
-        if first_section_elems:
-            return first_section_elems
-        first_page_elems = self.style_docx.get_first_page_elements()
-        if first_page_elems:
-            return first_page_elems
+    def get_coverpage_elements(self, n=1):
+        cover_elems = self.style_docx.get_first_page_elements(n)
+        if cover_elems:
+            return cover_elems
         return []
 
     def new_id(self):

--- a/docxbuilder/writer.py
+++ b/docxbuilder/writer.py
@@ -2177,9 +2177,9 @@ class DocxTranslator(nodes.NodeVisitor):
                 # Search for file
                 filepath = None
                 for file in os.listdir(imgdir):
-                    if os.path.splitext(os.path.basename(file))[0] == imghash:
+                    if os.path.splitext(file)[0] == imghash:
                         # Image has been downloaded, use this file
-                        filepath = file
+                        filepath = os.path.join(imgdir, file)
 
                 # Download image if nonexistant
                 if not filepath:

--- a/docxbuilder/writer.py
+++ b/docxbuilder/writer.py
@@ -25,6 +25,8 @@ import os
 import posixpath
 import re
 import sys
+import urllib.request
+import imghdr
 
 from docutils import nodes, writers
 from sphinx import addnodes, version_info
@@ -2163,15 +2165,42 @@ class DocxTranslator(nodes.NodeVisitor):
         def get_filepath(self, node):
             uri = node['uri']
             if uri.find('://') != -1:
-                raise RuntimeError('Not support remote image files yet')
-            filepath = os.path.join(self._builder.srcdir, uri)
-            if not os.path.exists(filepath):
-                # Some extensions output images in imagedir
-                filepath = os.path.join(
-                    self._builder.outdir, self._builder.imagedir, uri)
-            if not os.path.exists(filepath):
-                # Some extensions output images in outdir
-                filepath = os.path.join(self._builder.outdir, uri)
+                # The image will be downloaded into the _build/docx/_images folder
+                # As a filename we use a md5 hash of the URI
+                # This ensures filename safety (no special characters) and uniqueness
+                imghash = hashlib.md5(uri.encode('utf-8')).hexdigest()
+                imgdir = os.path.join(self._builder.outdir, '_images')
+
+                if not os.path.isdir(imgdir):
+                    os.mkdir(imgdir)
+
+                # Search for file
+                filepath = None
+                for file in os.listdir(imgdir):
+                    if os.path.splitext(os.path.basename(file))[0] == imghash:
+                        # Image has been downloaded, use this file
+                        filepath = file
+
+                # Download image if nonexistant
+                if not filepath:
+                    self._logger.info('downloading image: ' + uri)
+                    path_tmp = os.path.join(imgdir, imghash)
+                    urllib.request.urlretrieve(uri, path_tmp)
+
+                    # Determine image file extension and rename the image
+                    # Word shows an error if there are images with the wrong type
+                    ext = imghdr.what(path_tmp)
+                    filepath = path_tmp + '.' + ext
+                    os.renames(path_tmp, filepath)
+            else:
+                filepath = os.path.join(self._builder.srcdir, uri)
+                if not os.path.exists(filepath):
+                    # Some extensions output images in imagedir
+                    filepath = os.path.join(
+                        self._builder.outdir, self._builder.imagedir, uri)
+                if not os.path.exists(filepath):
+                    # Some extensions output images in outdir
+                    filepath = os.path.join(self._builder.outdir, uri)
             return filepath
         self.visit_image_node(
             node, node.get('alt', node['uri']), get_filepath)

--- a/docxbuilder/writer.py
+++ b/docxbuilder/writer.py
@@ -839,7 +839,7 @@ class DocxTranslator(nodes.NodeVisitor):
             stylefile = os.path.join(
                 os.path.dirname(__file__), 'docx/style.docx')
         self._docx = docx.DocxComposer(
-            stylefile, builder.config['docx_coverpage'])
+            stylefile, int(builder.config['docx_coverpage']))
         default_orient, sect_props = self._docx.get_section_properties()
         self._doc_stack = []
         self._doc_stack.append(

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ lxml>=4.4.0
 Pillow>=6.1.0
 Sphinx>=1.7.6
 sphinx-rtd-theme>=0.4.3
+six

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(os.path.join(BASEDIR, 'README.rst'), 'r') as f:
 
 setup(
     name='docxbuilder',
-    version='1.2.0',
+    version='1.3.0',
     description='Sphinx docx builder extension',
     long_description=LONG_DESCRIPTION,
     url='https://github.com/amedama41/docxbuilder',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(os.path.join(BASEDIR, 'README.rst'), 'r') as f:
 
 setup(
     name='docxbuilder',
-    version='1.3.0',
+    version='1.3.1',
     description='Sphinx docx builder extension',
     long_description=LONG_DESCRIPTION,
     url='https://github.com/amedama41/docxbuilder',


### PR DESCRIPTION
For my project I needed to have multiple cover pages.

So I changed the docx_coverpage config option to be an integer which specifies the number of cover pages.

Docxbuilder then inserts the first n pages from the stylefile into the document.