### PR TITLE
Add option to hide section numbers and option to hide subtocs

### DIFF
--- a/docs/source/docxbuilder.rst
+++ b/docs/source/docxbuilder.rst
@@ -97,6 +97,10 @@ customize the docx document properties.
   is numbered. When this is setting is not set to true, headers would have
   double section numbers.
   Default: ``False``.
+**docx_hide_subtoctrees**
+  If true, any TOC tree that is not in the root document will be hidden from
+  the Word output.
+  Default: ``False``.
 **docx_table_options**
   A dictionary with table layout options.
   The following options are supported.

--- a/docs/source/docxbuilder.rst
+++ b/docs/source/docxbuilder.rst
@@ -91,6 +91,12 @@ customize the docx document properties.
   If true, Office Word will ask to update fields in generated documents when the document is opened.
   This is useful when generated documents references some document properties.
   Default: ``False``.
+**docx_hide_section_numbers**
+  If true, section numbers will be removed from section titles.
+  This is useful when Word header styles are auto-numbered, and the Sphinx toctree
+  is numbered. When this is setting is not set to true, headers would have
+  double section numbers.
+  Default: ``False``.
 **docx_table_options**
   A dictionary with table layout options.
   The following options are supported.

--- a/docxbuilder/__init__.py
+++ b/docxbuilder/__init__.py
@@ -30,6 +30,7 @@ def setup(app):
     app.add_config_value('docx_pagebreak_after_table_of_contents', 0, 'env')
     app.add_config_value('docx_coverpage', True, 'env')
     app.add_config_value('docx_update_fields', False, 'env')
+    app.add_config_value('docx_hide_section_numbers', False, 'env')
     app.add_config_value('docx_table_options', {
         'landscape_columns': 0,
         'in_single_page': False,

--- a/docxbuilder/__init__.py
+++ b/docxbuilder/__init__.py
@@ -31,6 +31,7 @@ def setup(app):
     app.add_config_value('docx_coverpage', True, 'env')
     app.add_config_value('docx_update_fields', False, 'env')
     app.add_config_value('docx_hide_section_numbers', False, 'env')
+    app.add_config_value('docx_hide_subtoctrees', False, 'env')
     app.add_config_value('docx_table_options', {
         'landscape_columns': 0,
         'in_single_page': False,

--- a/docxbuilder/writer.py
+++ b/docxbuilder/writer.py
@@ -2194,6 +2194,9 @@ class DocxTranslator(nodes.NodeVisitor):
         raise nodes.SkipNode
 
     def visit_toctree(self, node):
+        is_root_doc = (self.builder.config.root_doc == self.builder.app.project.path2doc(node.source))
+        if not is_root_doc and self.builder.config.docx_hide_subtoctrees:
+            return
         if node.get('hidden', False):
             return
         caption = node.get('caption')

--- a/docxbuilder/writer.py
+++ b/docxbuilder/writer.py
@@ -1304,7 +1304,10 @@ class DocxTranslator(nodes.NodeVisitor):
         elif isinstance(node.parent, nodes.section):
             style = 'Heading %d' % self._section_level
             self._docx.create_style('paragraph', style, 'Heading', False)
-            title_num = self._get_numsec(node.parent['ids'])
+            if self.builder.config.docx_hide_section_numbers:
+                title_num = None
+            else:
+                title_num = self._get_numsec(node.parent['ids'])
             indent = None
             right_indent = None
             align = None
@@ -1323,7 +1326,7 @@ class DocxTranslator(nodes.NodeVisitor):
             align = None
         self._doc_stack.append(self._make_paragraph(
             indent, right_indent, style, align, keep_next=True))
-        if title_num is not None and not self.builder.config.docx_hide_section_numbers:
+        if title_num is not None:
             self._doc_stack[-1].add_text(title_num)
 
     def depart_title(self, node):

--- a/docxbuilder/writer.py
+++ b/docxbuilder/writer.py
@@ -1323,7 +1323,7 @@ class DocxTranslator(nodes.NodeVisitor):
             align = None
         self._doc_stack.append(self._make_paragraph(
             indent, right_indent, style, align, keep_next=True))
-        if title_num is not None:
+        if title_num is not None and not self.builder.config.docx_hide_section_numbers:
             self._doc_stack[-1].add_text(title_num)
 
     def depart_title(self, node):


### PR DESCRIPTION
This adds two config values:

* `docx_hide_section_numbers`, which when set to true, will remove section numbers from section titles. This is useful when Word header styles are auto-numbered, and the Sphinx toctree is numbered. When this is setting is not set to true, headers would have double section numbers.

* `docx_hide_subtoctrees`, which when set to true, will remove any TOC tree that is not in the root document from the Word output.